### PR TITLE
Add 'watch' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/copilot",
   "scripts": {
     "test": "ts-node node_modules/jasmine/bin/jasmine",
+    "watch": "tsc -w",
     "build": "tsc"
   },
   "author": "Fred Choi",


### PR DESCRIPTION
This allows users to run 'npm run-script watch' to enable automatic
recompilation of the TypeScript files.